### PR TITLE
add flask-talisman to force all connects to https

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import limits.util
 import redis
 from flask import Flask
 from flask_compress import Compress
+from flask_talisman import Talisman
 from flask_sqlalchemy import SQLAlchemy
 from limits.storage.redis import RedisStorage
 import sentry_sdk
@@ -59,6 +60,7 @@ class NullPoolSQLAlchemy(SQLAlchemy):
 
 db = NullPoolSQLAlchemy(app, session_options={"autoflush": False})
 
+Talisman(app, force_https=True)
 Compress(app)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask-Compress==1.10.1
 Flask-Limiter==2.0.2
 Flask-SQLAlchemy==2.5.1
+flask-talisman==1.0.0
 Flask==2.0.2
 gunicorn==20.1.0
 Jinja2==3.0.3


### PR DESCRIPTION
My hunch is that this is the point in the API where we can force https. The [flask-talisman](https://github.com/GoogleCloudPlatform/flask-talisman) library seems mature and well-maintained. It should force all (non-debug) http requests to https.

@caseydm I would like your review on this, since I'm not 100% sure how the networking ecosystem around the API works. Do you think this should work okay, and I can test it out?